### PR TITLE
Fix EKS group in XRD

### DIFF
--- a/apis/eks/definition.yaml
+++ b/apis/eks/definition.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   connectionSecretKeys:
   - kubeconfig
-  group: k8s.aws.starter.org
+  group: aws.k8s.starter.org
   names:
     kind: XEKS
     plural: xeks


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

The ordering of k8s and aws was reversed from the name on the XRD. This updates to make them match.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified the `KubernetesCluster` composition is now able to successfully identify the `XEKS` type.